### PR TITLE
Adjust rounding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 /// use tau::TAU;
 /// assert_eq!(TAU.cos(), 1.0);
 /// ```
-pub const TAU: f64 = 6.28318530717958647692528676655900576_f64;
+pub const TAU: f64 = 6.28318530717958647692528676655900577_f64;
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
I like τ because it's bigger than π. I think we can make it a little bigger yet.

The proposal is to round up, rather than down. This gets us closer to the exact value. (One might regard τ as a scaling quantity, rather than as a shifting quantity, and thus care more about the distance in a multiplicative sense, |ln(`TAU`/τ)|, than in an additive sense, |`TAU` - τ|. The new value is closer in both senses.)

For verification:

 - [Wolfram Alpha](https://www.wolframalpha.com/input?i=2*pi)
 - [OEIS](https://oeis.org/A019692)
 - [The Rust Standard Library](https://doc.rust-lang.org/1.47.0/std/f64/consts/constant.TAU.html) (Yeah, it does include `TAU` now.)

The test [`assert_eq!(PI, TAU / 2.0)`](https://github.com/FranklinChen/rust-tau/blob/31abd656fb6b9fcd4082143fd760c2a5ce8e7c49/src/lib.rs#L21) remains valid. In fact, the resulting floating-point value is the same as before, so nothing changes. Do we know why there is an overabundance of digits included?

Edit: Removed erroneous minus sign.